### PR TITLE
Look for Boxen’s postgres env var so that it just works in Boxenated dev environments

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -50,7 +50,8 @@ module EventSourceryTodoApp
 end
 
 EventSourceryTodoApp.configure do |config|
-  config.database_url = "postgres://127.0.0.1:5432/event_sourcery_todo_app_#{EventSourceryTodoApp.environment}"
+  postgres_port = ENV['BOXEN_POSTGRESQL_PORT'] || 5432
+  config.database_url = "postgres://127.0.0.1:#{postgres_port}/event_sourcery_todo_app_#{EventSourceryTodoApp.environment}"
 end
 
 EventSourcery::Postgres.configure do |config|


### PR DESCRIPTION
Otherwise, the setup script fails:

```
--- Creating and migrating databases
rake aborted!
Sequel::DatabaseConnectionError: PG::ConnectionBad: could not connect to server: Connection refused
        Is the server running on host "127.0.0.1" and accepting
        TCP/IP connections on port 5432?
```