### PR TITLE
Setup better errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,4 +17,5 @@ group :development, :test do
   gem 'rack-test'
   gem 'database_cleaner'
   gem 'shotgun'
+  gem 'better_errors'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,10 +2,15 @@ GEM
   remote: https://rubygems.org/
   remote: https://rubygems.envato.com/
   specs:
+    better_errors (2.1.1)
+      coderay (>= 1.0.0)
+      erubis (>= 2.6.6)
+      rack (>= 0.9.0)
     byebug (9.0.6)
     coderay (1.1.1)
     database_cleaner (1.6.1)
     diff-lcs (1.3)
+    erubis (2.7.0)
     event_sourcery (0.12.0)
     event_sourcery-postgres (0.2.0)
       event_sourcery (>= 0.10.0)
@@ -55,6 +60,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  better_errors
   database_cleaner
   event_sourcery!
   event_sourcery-postgres!
@@ -67,4 +73,4 @@ DEPENDENCIES
   sinatra
 
 BUNDLED WITH
-   1.15.0
+   1.15.1

--- a/app/web/server.rb
+++ b/app/web/server.rb
@@ -14,6 +14,12 @@ module EventSourceryTodoApp
     # Ensure our error handlers are triggered in development
     set :show_exceptions, :after_handler
 
+    configure :development do
+      require 'better_errors'
+      use BetterErrors::Middleware
+      BetterErrors.application_root = __dir__
+    end
+
     error UnprocessableEntity do |error|
       body "Unprocessable Entity: #{error.message}"
       status 422


### PR DESCRIPTION
This allows us to have nicer plain text errors when doing requests to the API via the command line.

    $ ./scripts/cli.rb list -l scheduled
    Scheduled todos

    Error:
      Sequel::DatabaseError at /todos/scheduled
    =========================================

    > PG::UndefinedTable: ERROR:  relation "query_scheduled_todos" does not exist
    LINE 1: SELECT * FROM "query_scheduled_todos" WHERE ("due_date" IS N...
                          ^


    server.rb, line 84
    ------------------

    ``` ruby
       79         status 200
       80       end
       81
       82       get '/todos/scheduled' do
       83         body JSON.pretty_generate(
    >  84           EventSourceryTodoApp::Projections::Scheduled::Query.handle
       85         )
       86         status 200
       87       end
       88
       89       get '/todos/completed' do
    ```

    App backtrace
    -------------

     - server.rb:84:in `block in <class:Server>'

    Full backtrace
    --------------

     - sequel (4.47.0) lib/sequel/adapters/postgres.rb:195:in `async_exec'
     - sequel (4.47.0) lib/sequel/adapters/postgres.rb:195:in `block in execute_query'
     - sequel (4.47.0) lib/sequel/database/logging.rb:45:in `log_connection_yield'
     - sequel (4.47.0) lib/sequel/adapters/postgres.rb:195:in `execute_query'
     - sequel (4.47.0) lib/sequel/adapters/postgres.rb:182:in `block in execute'
     - sequel (4.47.0) lib/sequel/adapters/postgres.rb:158:in `check_disconnect_errors'
     - sequel (4.47.0) lib/sequel/adapters/postgres.rb:182:in `execute'
     - sequel (4.47.0) lib/sequel/adapters/postgres.rb:535:in `_execute'
     - sequel (4.47.0) lib/sequel/adapters/postgres.rb:351:in `block (2 levels) in execute'
     - sequel (4.47.0) lib/sequel/adapters/postgres.rb:557:in `check_database_errors'
     - sequel (4.47.0) lib/sequel/adapters/postgres.rb:351:in `block in execute'
     - sequel (4.47.0) lib/sequel/database/connecting.rb:301:in `block in synchronize'
