### PR TITLE
Tweak request script

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Then you can manage your Todos using `request` CLI script.
 $ ./scripts/request add -i aac35923-39b4-4c39-ad5d-f79d67bb2fb2 -t "Get to the chopper" -d "It's in the trees" -s dillon@cia.gov -D 2017-01-01
 
 # Amend
-$ ./scripts/request amend -t "Get to the chopper, NOW!" -i aac35923-39b4-4c39-ad5d-f79d67bb2fb2
+$ ./scripts/request amend -i aac35923-39b4-4c39-ad5d-f79d67bb2fb2 -t "Get to the chopper, NOW!"
 
 # Complete
 $ ./scripts/request complete -i aac35923-39b4-4c39-ad5d-f79d67bb2fb2 -D 2017-01-01

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Then you can manage your Todos using `request` CLI script.
 
 ```sh
 # Add a todo
-$ ./scripts/request add -t "Get to the chopper" -d "It's in the trees" -s dillon@cia.gov -D 2017-01-01
+$ ./scripts/request add -i aac35923-39b4-4c39-ad5d-f79d67bb2fb2 -t "Get to the chopper" -d "It's in the trees" -s dillon@cia.gov -D 2017-01-01
 
 # Amend
 $ ./scripts/request amend -t "Get to the chopper, NOW!" -i aac35923-39b4-4c39-ad5d-f79d67bb2fb2

--- a/scripts/request
+++ b/scripts/request
@@ -68,6 +68,7 @@ command :add do |c|
   c.summary = 'Add a Todo item via the Todo web API'
   c.example 'Add a Todo', %Q{#{script_name} add -i 0b341422-c516-4ee4-8f3e-ef1992dfff32 -t "My task"}
   c.example 'Add a more complex Todo', %Q{#{script_name} add -i 0b341422-c516-4ee4-8f3e-ef1992dfff32 -t "My task" -d "My task description" -D 2017-01-01 -s stakeholder@example.com}
+  c.example 'Add a Todo', %Q{#{script_name} add -i $(#{script_name} uuid) -t "My task"}
   c.option '-i ID', '--id ID', 'Todo ID'
   c.option '-t TITLE', '--title TITLE', 'Title'
   c.option '-d DESCRIPTION', '--description DESCRIPTION', 'Description'
@@ -155,5 +156,14 @@ command :list do |c|
 
     puts "#{list.capitalize} todos"
     Request.call(:get, "/todos/#{list}")
+  end
+end
+
+command :uuid do |c|
+  c.syntax = 'Todo uuid'
+  c.summary = 'Generate a UUID'
+  c.example 'Generate a UUID', "#{script_name} uuid"
+  c.action do |args, options|
+    puts SecureRandom.uuid
   end
 end

--- a/scripts/request
+++ b/scripts/request
@@ -66,14 +66,20 @@ script_name = $0
 command :add do |c|
   c.syntax = 'Todo add [options]'
   c.summary = 'Add a Todo item via the Todo web API'
-  c.example 'Add a Todo', %Q{#{script_name} add -t "My task"}
-  c.example 'Add a more complex Todo', %Q{#{script_name} add -t "My task" -d "My task description" -D 2017-01-01 -s stakeholder@example.com}
+  c.example 'Add a Todo', %Q{#{script_name} add -i 0b341422-c516-4ee4-8f3e-ef1992dfff32 -t "My task"}
+  c.example 'Add a more complex Todo', %Q{#{script_name} add -i 0b341422-c516-4ee4-8f3e-ef1992dfff32 -t "My task" -d "My task description" -D 2017-01-01 -s stakeholder@example.com}
+  c.option '-i ID', '--id ID', 'Todo ID'
   c.option '-t TITLE', '--title TITLE', 'Title'
   c.option '-d DESCRIPTION', '--description DESCRIPTION', 'Description'
   c.option '-D DUE_DATE', '--due_date DUE_DATE', 'Due date'
   c.option '-s STAKEHOLDER_EMAIL', '--stakeholder_email STAKEHOLDER_EMAIL', 'Stakeholder email'
   c.action do |args, options|
-    todo_id = SecureRandom.uuid
+    todo_id = options.id
+    unless todo_id
+      $stderr.puts "Error: you must specify a Todo ID for the new Todo"
+      $stderr.puts "You can generate one using `#{script_name} uuid`."
+      exit 1
+    end
     payload = slice_and_compact(options.default, :title, :description, :due_date, :stakeholder_email)
     puts "Adding todo [#{todo_id}]: #{payload}"
     Request.call(:post, "/todo/#{todo_id}", payload)

--- a/scripts/request
+++ b/scripts/request
@@ -64,7 +64,7 @@ never_trace!
 script_name = $0
 
 command :add do |c|
-  c.syntax = 'Todo add [options]'
+  c.syntax = "#{script_name} add [options]"
   c.summary = 'Add a Todo item via the Todo web API'
   c.example 'Add a Todo', %Q{#{script_name} add -i 0b341422-c516-4ee4-8f3e-ef1992dfff32 -t "My task"}
   c.example 'Add a more complex Todo', %Q{#{script_name} add -i 0b341422-c516-4ee4-8f3e-ef1992dfff32 -t "My task" -d "My task description" -D 2017-01-01 -s stakeholder@example.com}
@@ -88,7 +88,7 @@ command :add do |c|
 end
 
 command :amend do |c|
-  c.syntax = 'Todo amend [options]'
+  c.syntax = "#{script_name} amend [options]"
   c.summary = 'Amend a Todo item via the Todo web API'
   c.example 'Amend the title of a Todo', %Q{#{script_name} add -i 0b341422-c516-4ee4-8f3e-ef1992dfff32 -t "My task"}
   c.option '-i ID', '--id ID', 'Existing Todo ID'
@@ -109,7 +109,7 @@ command :amend do |c|
 end
 
 command :abandon do |c|
-  c.syntax = 'Todo abandon [options]'
+  c.syntax = "#{script_name} abandon [options]"
   c.summary = 'Abandon a Todo item via the Todo web API'
   c.example 'Abandon a Todo', %Q{#{script_name} abandon -i 0b341422-c516-4ee4-8f3e-ef1992dfff32 -a 2017-01-01}
   c.option '-i ID', '--id ID', 'Existing Todo ID'
@@ -123,7 +123,7 @@ command :abandon do |c|
 end
 
 command :complete do |c|
-  c.syntax = 'Todo complete [options]'
+  c.syntax = "#{script_name} complete [options]"
   c.summary = 'Complete a Todo item via the Todo web API'
   c.example 'Complete a Todo', %Q{#{script_name} complete -i 0b341422-c516-4ee4-8f3e-ef1992dfff32 -a 2017-01-01}
   c.option '-i ID', '--id ID', 'Existing Todo ID'
@@ -143,7 +143,7 @@ command :list do |c|
     'completed',
   ]
 
-  c.syntax = 'Todo list [options]'
+  c.syntax = "#{script_name} list [options]"
   c.summary = 'List Todos via the Todo web API'
   c.example 'List outstanding Todos', %Q{#{script_name} list -l outstanding}
   c.option '-l LIST', '--list', "List to display: #{LISTS.join(', ')}"
@@ -160,7 +160,7 @@ command :list do |c|
 end
 
 command :uuid do |c|
-  c.syntax = 'Todo uuid'
+  c.syntax = "#{script_name} uuid"
   c.summary = 'Generate a UUID'
   c.example 'Generate a UUID', "#{script_name} uuid"
   c.action do |args, options|


### PR DESCRIPTION
Sebastian brought up a good point that the request script is a bit misleading because we don't require passing in an ID when adding a Todo. I've tweaked the script to require an ID and added a `./scripts/request uuid` sub command for generating them easily.