### PR TITLE
Tiny fixes to the walkthrough in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Then you can manage your Todos using the `request` CLI script.
 $ ./scripts/request add -i aac35923-39b4-4c39-ad5d-f79d67bb2fb2 -t "Get to the chopper" -d "It's in the trees" -s dillon@cia.gov -D 2017-01-01
 
 # Amend
-$ ./scripts/request amend -i aac35923-39b4-4c39-ad5d-f79d67bb2fb2 -t "Get to the chopper, NOW!"
+$ ./scripts/request amend -i aac35923-39b4-4c39-ad5d-f79d67bb2fb2 -t "Get to the chopper, NOW"
 
 # Complete
 $ ./scripts/request complete -i aac35923-39b4-4c39-ad5d-f79d67bb2fb2 -D 2017-01-01

--- a/app/aggregates/todo.rb
+++ b/app/aggregates/todo.rb
@@ -25,6 +25,9 @@ module EventSourceryTodoApp
         @abandoned = true
       end
 
+      apply StakeholderNotifiedOfTodoCompletion do |event|
+      end
+
       def add(payload)
         raise UnprocessableEntity, "Todo #{id.inspect} already exists" if added?
 

--- a/scripts/request
+++ b/scripts/request
@@ -111,7 +111,7 @@ end
 command :abandon do |c|
   c.syntax = "#{script_name} abandon [options]"
   c.summary = 'Abandon a Todo item via the Todo web API'
-  c.example 'Abandon a Todo', %Q{#{script_name} abandon -i 0b341422-c516-4ee4-8f3e-ef1992dfff32 -a 2017-01-01}
+  c.example 'Abandon a Todo', %Q{#{script_name} abandon -i 0b341422-c516-4ee4-8f3e-ef1992dfff32 -D 2017-01-01}
   c.option '-i ID', '--id ID', 'Existing Todo ID'
   c.option '-D ABANDONED_ON', '--abandoned_on ABANDONED_ON', 'Abandoned on'
   c.action do |args, options|
@@ -125,7 +125,7 @@ end
 command :complete do |c|
   c.syntax = "#{script_name} complete [options]"
   c.summary = 'Complete a Todo item via the Todo web API'
-  c.example 'Complete a Todo', %Q{#{script_name} complete -i 0b341422-c516-4ee4-8f3e-ef1992dfff32 -a 2017-01-01}
+  c.example 'Complete a Todo', %Q{#{script_name} complete -i 0b341422-c516-4ee4-8f3e-ef1992dfff32 -D 2017-01-01}
   c.option '-i ID', '--id ID', 'Existing Todo ID'
   c.option '-D COMPLETED_ON', '--completed_on COMPLETED_ON', 'Completed on'
   c.action do |args, options|


### PR DESCRIPTION
Was having a look at @grassdog's [recent changes](https://github.com/envato/event_sourcery_todo_app/pull/21) last night and ran into a couple of tiny errors while walking through the readme. @grassdog your fix prevents the error that I was previously seeing, I can't replicate the previous race condition anymore, nice work 👍 

The `amend` request was throwing a bash error for me because of the bang! in the example though so I removed it from the example data:
```
$ ./scripts/request amend -i aac35923-39b4-4c39-ad5d-f79d67bb2fb2 -t "Get to the chopper, NOW!"
-bash: !": event not found
```

Running the example requests in the readme sequentially (add, amend, complete and then abandon) also throws an error so I added the `StakeholderNotifiedOfTodoCompletion` event to the Todo aggregate (is this the correct solution for this?):
```
Error:
  EventSourcery::AggregateRoot::UnknownEventError at /todo/aac35923-39b4-4c39-ad5d-f79d67bb2fb2/abandon
=====================================================================================================

> stakeholder_notified_of_todo_completion is unknown to EventSourceryTodoApp::Aggregates::Todo
```
