### PR TITLE
[Bug Fix] Set the event_source from the config

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -37,7 +37,7 @@ module EventSourceryTodoApp
   end
 
   def self.event_source
-    EventSourcery::Postgres.config.event_store
+    EventSourcery::Postgres.config.event_source
   end
 
   def self.tracker


### PR DESCRIPTION
#### Context

I am currently learning about the wild world of Event Sourcing. Whilst playing around with this app I stumbled upon a small possible bug. 

#### Change

Set the `event_source` to `event_source` from the Postgres config. 