### PR TITLE
Remove Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-sudo: false
-language: ruby
-rvm: 2.4
-before_install:
-  - gem install bundler
-before_script:
-  - RACK_ENV=test bundle exec rake db:create db:migrate
-addons:
-  postgresql: 9.4

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Event Sourcery Todo Example App
 
-[![Build Status](https://travis-ci.org/envato/event_sourcery_todo_app.svg?branch=master)](https://travis-ci.org/envato/event_sourcery_todo_app)
-
 [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
 
 An example event sourced/CQRS web application built using [EventSourcery](https://github.com/envato/event_sourcery) and its [Postgres event store implementation](https://github.com/envato/event_sourcery-postgres).


### PR DESCRIPTION
🔥 

As of #40, we're using GitHub Actions to run the test suite and ensure continuous integration.